### PR TITLE
Make strapi name lowercase

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-next.3",
   "description": "Strapi plugin for managing and automating translation of content",
   "strapi": {
-    "name": "Translate",
+    "name": "translate",
     "description": "Manage and automate content translation",
     "kind": "plugin"
   },


### PR DESCRIPTION
I got this error:

```
Error: Plugin name "Translate" is not in kebab (an-example-of-kebab-case)
    at validatePluginName (/Users/strapi/node_modules/@strapi/strapi/lib/core/loaders/plugins/get-enabled-plugins.js:21:11)
```

Seems that the name should be lower case:

> 3\. Choose "plugin" from the list, press Enter, and give the plugin a name in kebab-case (e.g. my-plugin)

https://docs.strapi.io/developer-docs/latest/development/plugins-development.html#create-a-plugin

See check in https://github.com/strapi/strapi/blob/141f89f81f4a18766b5c5c0c545daf79e2760ede/packages/core/strapi/lib/core/loaders/plugins/get-enabled-plugins.js#L19
