### PR TITLE
feat(provider-deepl): support custom locale mapping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,17 +7,21 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/plugin/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/providers/deepl/"
+    target-branch: "next"
     schedule:
       interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/playground/"
+    target-branch: "next"
     schedule:
       interval: "weekly"

--- a/providers/deepl/README.md
+++ b/providers/deepl/README.md
@@ -16,6 +16,11 @@ module.exports = {
         apiKey: 'key',
         // use custom api url - optional
         apiUrl: 'https://api-free.deepl.com',
+        // use custom locale mapping (for example 'en' locale is deprecated so need to choose between 'EN-GB' and 'EN-US')
+        localeMap: {
+          // use uppercase here!
+          EN: 'EN-US',
+        },
       },
       // other options ...
     },

--- a/providers/deepl/lib/__tests__/parse-locale.test.js
+++ b/providers/deepl/lib/__tests__/parse-locale.test.js
@@ -52,4 +52,10 @@ describe('locale parser', () => {
       expect(() => parseLocale(code)).toThrow()
     })
   })
+  it('uses locale mapping', () => {
+    const localeMap = {
+      EN: 'EN-GB',
+    }
+    expect(parseLocale('en', localeMap)).toMatch('EN-GB')
+  })
 })

--- a/providers/deepl/lib/index.js
+++ b/providers/deepl/lib/index.js
@@ -22,6 +22,10 @@ module.exports = {
   init(providerOptions = {}) {
     const apiKey = process.env.DEEPL_API_KEY || providerOptions.apiKey
     const apiUrl = process.env.DEEPL_API_URL || providerOptions.apiUrl
+    const localeMap =
+      typeof providerOptions.localeMap === 'object'
+        ? providerOptions.localeMap
+        : {}
 
     const client = new deepl.Translator(apiKey, {
       serverUrl: apiUrl,
@@ -80,8 +84,8 @@ module.exports = {
                       : DEEPL_PRIORITY_DEFAULT,
                 },
                 texts,
-                parseLocale(sourceLocale),
-                parseLocale(targetLocale),
+                parseLocale(sourceLocale, localeMap),
+                parseLocale(targetLocale, localeMap),
                 { tagHandlingMode }
               )
               return result.map((value) => value.text)

--- a/providers/deepl/lib/parse-locale.js
+++ b/providers/deepl/lib/parse-locale.js
@@ -1,8 +1,25 @@
 'use strict'
 
-function parseLocale(strapiLocale) {
+const defaults = require('lodash/defaults')
+
+const defaultLocaleMap = {
+  PT: 'PT-PT',
+  EN: 'EN-US',
+  // english creole variants. Translating them to english by default
+  AIG: 'EN-US',
+  BAH: 'EN-US',
+  SVC: 'EN-US',
+  VIC: 'EN-US',
+  LIR: 'EN-US',
+  TCH: 'EN-US',
+}
+
+function parseLocale(strapiLocale, localeMap = {}) {
   const unstripped = strapiLocale.toUpperCase()
   const stripped = unstripped.split('-')[0]
+
+  defaults(localeMap, defaultLocaleMap)
+
   switch (stripped) {
     case 'BG':
     case 'CS':
@@ -29,25 +46,20 @@ function parseLocale(strapiLocale) {
     case 'TR':
     case 'UK':
     case 'ZH':
-      return stripped
+      return localeMap[stripped] || stripped
     case 'PT':
       if (unstripped == 'PT-PT') return unstripped
       if (unstripped == 'PT-BR') return unstripped
-      return stripped
-    // english creole variants. Translating them to english by default
-    case 'AIG':
-    case 'BAH':
-    case 'SVC':
-    case 'VIC':
-    case 'LIR':
-    case 'TCH':
-      return 'EN'
+      return localeMap[stripped]
     case 'EN':
       if (unstripped == 'EN-GB') return unstripped
       if (unstripped == 'EN-US') return unstripped
-      return stripped
+      return localeMap[stripped]
 
     default:
+      if (localeMap[stripped]) return localeMap[stripped]
+      if (localeMap[unstripped]) return localeMap[unstripped]
+      if (localeMap[strapiLocale]) return localeMap[strapiLocale]
       throw new Error('unsupported locale')
   }
 }

--- a/providers/deepl/package.json
+++ b/providers/deepl/package.json
@@ -54,6 +54,7 @@
     "msw": "^0.47.4"
   },
   "peerDependencies": {
-    "strapi-plugin-translate": "1.0.0"
+    "strapi-plugin-translate": "1.0.0",
+    "lodash": "*"
   }
 }


### PR DESCRIPTION
The 'EN' and 'PT' locale are deprecated in favor of the more specific versions. This feature fixes
the issue and allows more customization so not everyone needs to use EN-US for the EN locale

fix https://github.com/Fekide/strapi-plugin-translate/issues/62