### PR TITLE
feat(provider-deepl): add optional parameters for deepl api 

### DIFF
--- a/providers/deepl/README.md
+++ b/providers/deepl/README.md
@@ -21,6 +21,13 @@ module.exports = {
           // use uppercase here!
           EN: 'EN-US',
         },
+        apiOptions: {
+          // see <https://github.com/DeepLcom/deepl-node#text-translation-options> for supported options.
+          // note that tagHandling Mode cannot be set this way. 
+          // use with caution, as non-default values may break translation of markdown 
+          formality: 'default',
+          // ...
+        }
       },
       // other options ...
     },

--- a/providers/deepl/lib/index.js
+++ b/providers/deepl/lib/index.js
@@ -26,6 +26,10 @@ module.exports = {
       typeof providerOptions.localeMap === 'object'
         ? providerOptions.localeMap
         : {}
+    const apiOptions =
+      typeof providerOptions.apiOptions === 'object'
+        ? providerOptions.apiOptions
+        : {}
 
     const client = new deepl.Translator(apiKey, {
       serverUrl: apiUrl,
@@ -86,7 +90,7 @@ module.exports = {
                 texts,
                 parseLocale(sourceLocale, localeMap),
                 parseLocale(targetLocale, localeMap),
-                { tagHandlingMode }
+                { ...apiOptions, tagHandlingMode }
               )
               return result.map((value) => value.text)
             })


### PR DESCRIPTION
As requested in #70 , optional parameters to the deepl API such as formality can now be configured in the prociderOptions