### PR TITLE
fix(provider-deepl): make parsed source local not include country

### DIFF
--- a/providers/deepl/lib/__tests__/parse-locale.test.js
+++ b/providers/deepl/lib/__tests__/parse-locale.test.js
@@ -58,4 +58,10 @@ describe('locale parser', () => {
   it('does not parse pt to PT as that is deprecated', () => {
     expect(parseLocale('pt')).not.toEqual('PT')
   })
+  it('source language is parsed without specific locale', () => {
+    expect(parseLocale('en-GB', 'source')).toEqual('EN')
+  })
+  it('source language is parsed without specific locale even with locale map', () => {
+    expect(parseLocale('en-GB', 'source')).toEqual('EN')
+  })
 })

--- a/providers/deepl/lib/index.js
+++ b/providers/deepl/lib/index.js
@@ -80,8 +80,8 @@ module.exports = {
                       : DEEPL_PRIORITY_DEFAULT,
                 },
                 texts,
-                parseLocale(sourceLocale),
-                parseLocale(targetLocale),
+                parseLocale(sourceLocale, 'source'),
+                parseLocale(targetLocale, 'target'),
                 { tagHandlingMode }
               )
               return result.map((value) => value.text)

--- a/providers/deepl/lib/parse-locale.js
+++ b/providers/deepl/lib/parse-locale.js
@@ -1,8 +1,16 @@
 'use strict'
 
-function parseLocale(strapiLocale) {
-  const unstripped = strapiLocale.toUpperCase()
+function stripAndUpper(locale) {
+  const unstripped = locale.toUpperCase()
   const stripped = unstripped.split('-')[0]
+
+  return { unstripped, stripped }
+}
+
+function parseLocale(strapiLocale, direction = 'target') {
+  const { unstripped, stripped } = stripAndUpper(strapiLocale)
+
+  let possiblyUnstrippedResult = stripped
   switch (stripped) {
     case 'BG':
     case 'CS':
@@ -29,11 +37,13 @@ function parseLocale(strapiLocale) {
     case 'TR':
     case 'UK':
     case 'ZH':
-      return stripped
+      possiblyUnstrippedResult = stripped
+      break
     case 'PT':
-      if (unstripped == 'PT-PT') return unstripped
-      if (unstripped == 'PT-BR') return unstripped
-      return 'PT-PT'
+      if (unstripped == 'PT-PT') possiblyUnstrippedResult = unstripped
+      else if (unstripped == 'PT-BR') possiblyUnstrippedResult = unstripped
+      else possiblyUnstrippedResult = 'PT-PT'
+      break
     // english creole variants. Translating them to english by default
     case 'AIG':
     case 'BAH':
@@ -41,15 +51,20 @@ function parseLocale(strapiLocale) {
     case 'VIC':
     case 'LIR':
     case 'TCH':
-      return 'EN-US'
+      possiblyUnstrippedResult = 'EN-US'
+      break
     case 'EN':
-      if (unstripped == 'EN-GB') return unstripped
-      if (unstripped == 'EN-US') return unstripped
-      return 'EN-US'
-
+      if (unstripped == 'EN-GB') possiblyUnstrippedResult = unstripped
+      else if (unstripped == 'EN-US') possiblyUnstrippedResult = unstripped
+      else possiblyUnstrippedResult = 'EN-US'
+      break
     default:
       throw new Error('unsupported locale')
   }
+  if (direction === 'source') {
+    return stripAndUpper(possiblyUnstrippedResult).stripped
+  }
+  return possiblyUnstrippedResult
 }
 
 module.exports = {


### PR DESCRIPTION
The source language in DeepL does not accept the country codes in translation

fix #73