### PR TITLE
fix(admin): fix error with strapi v4.8

### DIFF
--- a/plugin/admin/src/components/Usage/index.js
+++ b/plugin/admin/src/components/Usage/index.js
@@ -23,39 +23,39 @@ const UsageOverview = () => {
     return null
   }
 
-  const content = error ? (
-    <Td>
-      <Typography textColor="neutral800">
-        {formatMessage({
-          id: getTrad('usage.failed-to-load'),
-          defaultMessage: 'Failed to load Usage data',
-        })}
-      </Typography>
-    </Td>
-  ) : (
-    <>
-      <Td>
-        <Typography textColor="neutral800">
-          {usage.count}/{usage.limit}{' '}
-          {formatMessage({
-            id: getTrad('usage.characters-used'),
-            defaultMessage: 'characters used',
-          })}
-        </Typography>
-      </Td>
-      <Td>
-        <CardBadge>
-          <ProgressBar value={usage ? (usage.count / usage.limit) * 100 : 0}>
+  const content = error
+    ? [
+        <Td key="error">
+          <Typography textColor="neutral800">
+            {formatMessage({
+              id: getTrad('usage.failed-to-load'),
+              defaultMessage: 'Failed to load Usage data',
+            })}
+          </Typography>
+        </Td>,
+      ]
+    : [
+        <Td key="usage">
+          <Typography textColor="neutral800">
             {usage.count}/{usage.limit}{' '}
             {formatMessage({
               id: getTrad('usage.characters-used'),
               defaultMessage: 'characters used',
             })}
-          </ProgressBar>
-        </CardBadge>
-      </Td>
-    </>
-  )
+          </Typography>
+        </Td>,
+        <Td key="progress-bar">
+          <CardBadge>
+            <ProgressBar value={usage ? (usage.count / usage.limit) * 100 : 0}>
+              {usage.count}/{usage.limit}{' '}
+              {formatMessage({
+                id: getTrad('usage.characters-used'),
+                defaultMessage: 'characters used',
+              })}
+            </ProgressBar>
+          </CardBadge>
+        </Td>,
+      ]
 
   return (
     <Box background="neutral100" marginTop={4}>


### PR DESCRIPTION
strapi v4.8 seems to throw error if Td element is not direct child of Tr element.

There was a React Fragment, which is now replaced by an array of Td elements.

fix #142