### PR TITLE
fix: enable table overflow-x

### DIFF
--- a/plugin/admin/src/components/Collection/CollectionTable.js
+++ b/plugin/admin/src/components/Collection/CollectionTable.js
@@ -1,6 +1,7 @@
 import React, { memo, useState, useEffect } from 'react'
 import { Table, Tbody } from '@strapi/design-system/Table'
 import { Box } from '@strapi/design-system/Box'
+import { Layout } from '@strapi/design-system/Layout'
 import { Dialog, DialogBody, DialogFooter } from '@strapi/design-system/Dialog'
 import { useIntl } from 'react-intl'
 import { useNotification } from '@strapi/helper-plugin'
@@ -150,7 +151,7 @@ const CollectionTable = () => {
   const COL_COUNT = locales.length + 1
 
   return (
-    <Box background="neutral100">
+    <Layout>
       <Table colCount={COL_COUNT} rowCount={ROW_COUNT}>
         <CollectionTableHeader locales={locales} />
         <Tbody>
@@ -275,7 +276,7 @@ const CollectionTable = () => {
           />
         </Dialog>
       )}
-    </Box>
+    </Layout>
   )
 }
 

--- a/plugin/admin/src/pages/HomePage/index.js
+++ b/plugin/admin/src/pages/HomePage/index.js
@@ -10,10 +10,10 @@ import PluginPage from '../../components/PluginPage'
 
 const HomePage = () => {
   return (
-    <div>
+    <>
       <PluginHeader />
       <PluginPage />
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
This PRs refactor's `Box` component to a `Layout` inside `CollectionTable.js`, so we can have proper overflow in the table, when we have multiple locales supported.

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/Fekide/strapi-plugin-translate/assets/12672541/919061c5-a26e-4084-b492-1ecb1adf1364"/>  | <img src="https://github.com/Fekide/strapi-plugin-translate/assets/12672541/4c0433ac-1de4-4520-b0a9-d80eedf36028"/>  |

Also removed redundant div, and replace with fragment.
