### PR TITLE
fix(single-translation): fix issue with JSON fields breaking the translation process

### DIFF
--- a/plugin/admin/src/components/CMEditViewTranslateLocale/index.js
+++ b/plugin/admin/src/components/CMEditViewTranslateLocale/index.js
@@ -181,10 +181,13 @@ const Content = ({
 
       for (const key in parsedData) {
         if (Object.hasOwnProperty.call(parsedData, key)) {
-          const value = parsedData[key]
+          let value = parsedData[key]
           const attribute = allLayoutData.contentType.attributes[key]
 
           if (attribute) {
+            if (attribute.type === 'json') {
+              value = JSON.stringify(value, undefined, 2)
+            }
             onChange({ target: { name: key, value, type: attribute.type } })
           }
         }


### PR DESCRIPTION
Previously, when a JSON field was present, the the field would fail to update and the tab would hang. this should now be fixed

re #246

I'm not entirely sure whether this addresses the main problem with #246, but it fixes a problem I encountered while looking into this.