### PR TITLE
fix(batch-translate): translation of single types

### DIFF
--- a/plugin/server/services/batch-translate/BatchTranslateJob.js
+++ b/plugin/server/services/batch-translate/BatchTranslateJob.js
@@ -223,7 +223,7 @@ class BatchTranslateJob {
         fullyTranslatedData.publishedAt =
           entity.publishedAt && this.autoPublish ? new Date() : null
         // Create localized entry
-        await strapi.service(this.contentType).create({
+        await strapi.entityService.create(this.contentType, {
           data: fullyTranslatedData,
           // Needed for syncing localizations
           populate: ['localizations'],


### PR DESCRIPTION
service create uses a different naming scheme for single types, so switching to entityService