### PR TITLE
fix(provider-deepl): add appInfo to DeepL Translator options

### DIFF
--- a/providers/deepl/lib/constants.js
+++ b/providers/deepl/lib/constants.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const packageJson = require("../package.json")
+
 module.exports = {
   DEEPL_FREE_API: 'https://api-free.deepl.com/v2',
   DEEPL_PAID_API: 'https://api.deepl.com/v2',
@@ -12,4 +14,8 @@ module.exports = {
   DEEPL_PRIORITY_DIRECT_TRANSLATION: 3,
   DEEPL_PRIORITY_USAGE: 1,
   DEEPL_PRIORITY_DEFAULT: 5,
+  DEEPL_APP_INFO: {
+    appName: packageJson.name,
+    appVersion: packageJson.version
+  }
 }

--- a/providers/deepl/lib/index.js
+++ b/providers/deepl/lib/index.js
@@ -7,6 +7,7 @@ const {
   DEEPL_PRIORITY_DEFAULT,
   DEEPL_API_MAX_TEXTS,
   DEEPL_API_ROUGH_MAX_REQUEST_SIZE,
+  DEEPL_APP_INFO
 } = require('./constants')
 const { parseLocale } = require('./parse-locale')
 const { getService } = require('./get-service')
@@ -33,6 +34,7 @@ module.exports = {
 
     const client = new deepl.Translator(apiKey, {
       serverUrl: apiUrl,
+      appInfo: DEEPL_APP_INFO
     })
 
     const limiter = new Bottleneck({


### PR DESCRIPTION
A requirement/advisory from the DeepL nodejs documentation: [deepl-node#writing-a-plugin](https://github.com/DeepLcom/deepl-node/tree/main#writing-a-plugin)