### PR TITLE
feat(provider-deepl): support Arabic

### DIFF
--- a/providers/deepl/lib/__tests__/parse-locale.test.js
+++ b/providers/deepl/lib/__tests__/parse-locale.test.js
@@ -7,6 +7,7 @@ function supportedLocale({ code, name }) {
   // Swiss German is not supported
   if (code.includes('gsw')) return false
   return [
+    "Arabic",
     'Bulgarian',
     'Czech',
     'Danish',

--- a/providers/deepl/lib/parse-locale.js
+++ b/providers/deepl/lib/parse-locale.js
@@ -28,6 +28,7 @@ function parseLocale(strapiLocale, localeMap = {}, direction = 'target') {
 
   let possiblyUnstrippedResult = stripped
   switch (stripped) {
+    case "AR":
     case 'BG':
     case 'CS':
     case 'DA':


### PR DESCRIPTION
## Description:
DeepL has added support for  `AR(Arabic)` locale. I wanted to use this locale in my cms for localization but the translate plugin was throwing the error `unsupported locale`. This PR intends to add support for the same.