### PR TITLE
fix(direct-translation): nested json fields and dynamic zones

### DIFF
--- a/playground/cypress/e2e/direct-translation.cy.js
+++ b/playground/cypress/e2e/direct-translation.cy.js
@@ -118,7 +118,7 @@ describe('direct translation', () => {
     cy.contains('span', 'tech').should('be.visible')
   })
 
-  it('single type with components', () => {
+  it('single type with components and dynamic zone', () => {
     cy.intercept('/translate/translate').as('translateExecution')
     cy.intercept('/content-manager/uid/check-availability').as('regenerateUID')
 
@@ -159,6 +159,16 @@ describe('direct translation', () => {
       })
       .get('img')
       .should('be.visible')
+
+    cy.contains('"subtitle"').should('be.visible')
+
+    cy.contains(
+      'This is a blog post about the latest news in the world. Stay tuned!'
+    ).should('be.visible')
+    cy.contains('We will talk about the latest tech news, stay tuned!').should(
+      'be.visible'
+    )
+
     cy.contains('button', 'Save').should('be.disabled')
   })
 

--- a/playground/data/data.json
+++ b/playground/data/data.json
@@ -33,8 +33,28 @@
       "shareImage": null
     },
     "hero": {
-      "title": "My blog"
-    }
+      "title": "My blog",
+      "additional": {
+        "subtitle": "Welcome to my blog"
+      }
+    },
+    "dynamicContent": [
+      {
+        "__component": "shared.category",
+        "category": 1,
+        "display": "Latest news"
+      },
+      {
+        "__component":"shared.content",
+        "title": "What's happening right now",
+        "content": "This is a blog post about the latest news in the world. Stay tuned!"
+      },
+      {
+        "__component": "shared.content",
+        "title": "Next up on this Website",
+        "content": "We will talk about the latest tech news, stay tuned!"
+      }
+    ]
   },
   "categories-page": {
     "categories": [

--- a/playground/src/api/article/content-types/article/schema.json
+++ b/playground/src/api/article/content-types/article/schema.json
@@ -9,8 +9,6 @@
     "description": ""
   },
   "options": {
-    "increments": true,
-    "timestamps": true,
     "draftAndPublish": true
   },
   "pluginOptions": {
@@ -75,7 +73,9 @@
       "type": "media",
       "multiple": false,
       "required": false,
-      "allowedTypes": ["images"],
+      "allowedTypes": [
+        "images"
+      ],
       "pluginOptions": {
         "translate": {
           "translate": "translate"
@@ -95,6 +95,14 @@
           "translate": "translate"
         }
       }
+    },
+    "json_props": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "json"
     }
   }
 }

--- a/playground/src/api/homepage/content-types/homepage/schema.json
+++ b/playground/src/api/homepage/content-types/homepage/schema.json
@@ -9,8 +9,6 @@
     "description": ""
   },
   "options": {
-    "increments": true,
-    "timestamps": true,
     "draftAndPublish": false
   },
   "pluginOptions": {
@@ -45,6 +43,21 @@
           "localized": true
         }
       }
+    },
+    "dynamicContent": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        },
+        "translate": {
+          "translate": "translate"
+        }
+      },
+      "type": "dynamiczone",
+      "components": [
+        "shared.content",
+        "shared.category"
+      ]
     }
   }
 }

--- a/playground/src/api/writer/content-types/writer/schema.json
+++ b/playground/src/api/writer/content-types/writer/schema.json
@@ -16,7 +16,11 @@
       "type": "string"
     },
     "picture": {
-      "allowedTypes": ["images", "files", "videos"],
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos"
+      ],
       "type": "media",
       "multiple": false
     },

--- a/playground/src/components/sections/hero.json
+++ b/playground/src/components/sections/hero.json
@@ -2,13 +2,18 @@
   "collectionName": "components_decoration_heroes",
   "info": {
     "name": "Hero",
-    "icon": "address-card"
+    "icon": "address-card",
+    "displayName": "Hero Sections",
+    "description": ""
   },
   "options": {},
   "attributes": {
     "title": {
       "type": "string",
       "required": true
+    },
+    "additional": {
+      "type": "json"
     }
   }
 }

--- a/playground/src/components/shared/content.json
+++ b/playground/src/components/shared/content.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_shared_contents",
+  "info": {
+    "displayName": "Content",
+    "icon": "write",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "content": {
+      "type": "richtext"
+    }
+  }
+}

--- a/plugin/admin/src/components/CMEditViewTranslateLocale/index.js
+++ b/plugin/admin/src/components/CMEditViewTranslateLocale/index.js
@@ -52,6 +52,7 @@ import { getTrad } from '../../utils'
 import permissions from '../../permissions'
 import useUsage from '../../Hooks/useUsage'
 import parseRelations from './utils/parse-relations'
+import flattenEntity from './utils/flattenEntity'
 
 const StyledTypography = styled(Typography)`
   svg {
@@ -89,8 +90,6 @@ const CMEditViewTranslateLocale = () => {
   if (!hasI18nEnabled || !localizations.length) {
     return null
   }
-
-  console.log(readPermissions)
 
   return (
     <CheckPermissions permissions={permissions.translate}>
@@ -185,22 +184,23 @@ const Content = ({
         'createdAt',
         'updatedAt',
       ].forEach((key) => {
-        _.omit(parsedData, key)
+        _.unset(parsedData, key)
 
         if (!initialData[key]) return
         parsedData[key] = initialData[key]
       })
 
-      for (const key in parsedData) {
-        if (Object.hasOwnProperty.call(parsedData, key)) {
-          let value = parsedData[key]
-          const attribute = allLayoutData.contentType.attributes[key]
+      const flattenedData = flattenEntity(parsedData, allLayoutData)
 
-          if (attribute) {
-            if (attribute.type === 'json') {
-              value = JSON.stringify(value, undefined, 2)
+      for (const key in flattenedData) {
+        if (Object.hasOwnProperty.call(flattenedData, key)) {
+          let { value, type } = flattenedData[key]
+
+          if (type) {
+            if (type === 'json') {
+              value = JSON.stringify(value)
             }
-            onChange({ target: { name: key, value, type: attribute.type } })
+            onChange({ target: { name: key, value, type } })
           }
         }
       }

--- a/plugin/admin/src/components/CMEditViewTranslateLocale/utils/flattenEntity.js
+++ b/plugin/admin/src/components/CMEditViewTranslateLocale/utils/flattenEntity.js
@@ -1,0 +1,83 @@
+import _ from 'lodash'
+
+/**
+ * @param data The data
+ * @param allLayoutData The schema of the data
+ * @param {null | string} component The name of a component or null for the content type
+ * @returns {{[key: string]: {value: any, type: string}}}
+ */
+export default function flattenEntity(
+  data,
+  allLayoutData,
+  component = null,
+  prefix = '',
+  componentIndex = null
+) {
+  const result = {}
+
+  const layoutData = component
+    ? allLayoutData.components[component]
+    : allLayoutData.contentType
+
+  if (data.__component) {
+    result[`${prefix}__component`] = {
+      value: data.__component,
+      type: 'component',
+    }
+  }
+  if (componentIndex !== null) {
+    result[`${prefix}__temp_key__`] = {
+      value: componentIndex,
+      type: 'component',
+    }
+  }
+
+  Object.keys(layoutData.attributes).forEach((attribute) => {
+    const attributeData = layoutData.attributes[attribute]
+
+    if (_.has(data, attribute)) {
+      const value = _.get(data, attribute)
+
+      if (attributeData.type === 'component') {
+        _.assign(
+          result,
+          ...(attributeData.repeatable
+            ? value.map((c, index) =>
+                flattenEntity(
+                  c,
+                  allLayoutData,
+                  attributeData.component,
+                  `${prefix}${attribute}.${index}.`,
+                  index
+                )
+              )
+            : [
+                flattenEntity(
+                  value,
+                  allLayoutData,
+                  attributeData.component,
+                  prefix + attribute + '.'
+                ),
+              ])
+        )
+      } else if (attributeData.type === 'dynamiczone' && Array.isArray(value)) {
+        _.assign(
+          result,
+          ...value.map((c, index) =>
+            flattenEntity(
+              c,
+              allLayoutData,
+              c.__component,
+              `${prefix}${attribute}.${index}.`,
+              index
+            )
+          )
+        )
+      } else {
+        result[prefix + attribute] = { value, type: attributeData.type }
+      }
+    }
+  })
+
+  return result
+}

--- a/plugin/admin/src/components/CMEditViewTranslateLocale/utils/parse-relations.js
+++ b/plugin/admin/src/components/CMEditViewTranslateLocale/utils/parse-relations.js
@@ -114,20 +114,16 @@ export default function parseRelations(data, allLayoutData, component = null) {
           result,
           attribute,
           attributeData.repeatable
-            ? value.map((c, index) => ({
-                __temp_key__: index,
-                ...parseRelations(c, allLayoutData, attributeData.component),
-              }))
+            ? value.map((c) =>
+                parseRelations(c, allLayoutData, attributeData.component)
+              )
             : parseRelations(value, allLayoutData, attributeData.component)
         )
       } else if (attributeData.type === 'dynamiczone' && Array.isArray(value)) {
         _.set(
           result,
           attribute,
-          value.map((c, index) => ({
-            __temp_key__: index,
-            ...parseRelations(c, allLayoutData, c.__component),
-          }))
+          value.map((c) => parseRelations(c, allLayoutData, c.__component))
         )
       }
     }


### PR DESCRIPTION
This pull request includes multiple changes across various files to enhance the translation and dynamic content features. The most important changes are grouped by their themes below:
### Plugin changes:

* [`plugin/admin/src/components/CMEditViewTranslateLocale/index.js`](diffhunk://#diff-c7bfa99923060ccd8b58a7d57a485849a0ad58957652bafd0001b147ca877abeR55): Introduced a new utility function `flattenEntity` and removed unnecessary console logs. Updated the data parsing logic to use the new utility function. [[1]](diffhunk://#diff-c7bfa99923060ccd8b58a7d57a485849a0ad58957652bafd0001b147ca877abeR55) [[2]](diffhunk://#diff-c7bfa99923060ccd8b58a7d57a485849a0ad58957652bafd0001b147ca877abeL93-L94) [[3]](diffhunk://#diff-c7bfa99923060ccd8b58a7d57a485849a0ad58957652bafd0001b147ca877abeL188-R203)
* [`plugin/admin/src/components/CMEditViewTranslateLocale/utils/flattenEntity.js`](diffhunk://#diff-8f8c16dc743d2dd13ecafb5122a557749c5794a3df185a52b594d0b4bc9a1378R1-R83): Added a new utility function `flattenEntity` to flatten entity data before updating the view
* [`plugin/admin/src/components/CMEditViewTranslateLocale/utils/parse-relations.js`](diffhunk://#diff-2289e91cceb3901646e62bb0b811bad9883a30eb1b4595fe6f606b4a57cad0d7L117-R126): Refactored the `parseRelations` function to simplify the handling of repeatable and dynamic zone attributes.

### Testing changes:

* [`playground/cypress/e2e/direct-translation.cy.js`](diffhunk://#diff-152c03854025d4061a5973ff8b8706ed74d432895b4b1633956c87e2842856f1L121-R121): Updated test descriptions and added assertions to verify the visibility of new dynamic content elements. [[1]](diffhunk://#diff-152c03854025d4061a5973ff8b8706ed74d432895b4b1633956c87e2842856f1L121-R121) [[2]](diffhunk://#diff-152c03854025d4061a5973ff8b8706ed74d432895b4b1633956c87e2842856f1R162-R171)

### Playground changes
#### Addition of Dynamic Content:

* [`playground/data/data.json`](diffhunk://#diff-992d2a29b23752130653c41b6708a30f6d35fd473576a44c2f7b6da9c934d463L36-R58): Introduced a new `dynamicContent` field with components for category and content, including titles and content descriptions.
* [`playground/src/api/homepage/content-types/homepage/schema.json`](diffhunk://#diff-38ae1895b93298034d43dc467b3c3c945b1efdf44ae243ee74713f002a6fa0a1R46-R60): Added a `dynamicContent` field with plugin options for localization and translation, and specified the components it can include.

#### Schema Modifications:

* [`playground/src/api/article/content-types/article/schema.json`](diffhunk://#diff-68617054d176de4dbd7094cf98bf0e918d063310df8daff9a1c1be5f5ed60a09R98-R105): Added a new `json_props` field with localization options and modified the `allowedTypes` field for media attributes. [[1]](diffhunk://#diff-68617054d176de4dbd7094cf98bf0e918d063310df8daff9a1c1be5f5ed60a09R98-R105) [[2]](diffhunk://#diff-68617054d176de4dbd7094cf98bf0e918d063310df8daff9a1c1be5f5ed60a09L78-R78)
* [`playground/src/api/writer/content-types/writer/schema.json`](diffhunk://#diff-8cb46becb012eb772f847598d15af0e38fa1803f69a8d9e7db5ed70d6ee18051L19-R23): Formatted the `allowedTypes` field for better readability.

#### Component Updates:

* [`playground/src/components/sections/hero.json`](diffhunk://#diff-b00f9d92039234c3d9301224e9a493a68dd4ddf951d8720a08a66b63997e0e7dL5-R16): Enhanced the `Hero` component with additional attributes and a display name.
* [`playground/src/components/shared/content.json`](diffhunk://#diff-fd68d5da9c01fcbd086d63afd8bbc8526fd63e24deade7fa6980b1f36f188c3cR1-R17): Added a new `Content` component definition with attributes for title and rich text content.