### PR TITLE
fix(direct-translation): errors with empty components

### DIFF
--- a/plugin/admin/src/components/CMEditViewTranslateLocale/utils/flattenEntity.js
+++ b/plugin/admin/src/components/CMEditViewTranslateLocale/utils/flattenEntity.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 /**
- * @param data The data
+ * @param {null | object} data The data
  * @param allLayoutData The schema of the data
  * @param {null | string} component The name of a component or null for the content type
  * @returns {{[key: string]: {value: any, type: string}}}
@@ -19,7 +19,7 @@ export default function flattenEntity(
     ? allLayoutData.components[component]
     : allLayoutData.contentType
 
-  if (data.__component) {
+  if (data?.__component) {
     result[`${prefix}__component`] = {
       value: data.__component,
       type: 'component',
@@ -38,28 +38,34 @@ export default function flattenEntity(
     if (_.has(data, attribute)) {
       const value = _.get(data, attribute)
 
-      if (attributeData.type === 'component') {
-        _.assign(
-          result,
-          ...(attributeData.repeatable
-            ? value.map((c, index) =>
-                flattenEntity(
-                  c,
-                  allLayoutData,
-                  attributeData.component,
-                  `${prefix}${attribute}.${index}.`,
-                  index
-                )
+      if (_.isEmpty(value)) {
+        // If the translated value is empty, it must be passed directly so it can be reset
+        result[prefix + attribute] = { value, type: attributeData.type }
+      } else if (attributeData.type === 'component') {
+        if (attributeData.repeatable) {
+          _.assign(
+            result,
+            ...value.map((c, index) =>
+              flattenEntity(
+                c,
+                allLayoutData,
+                attributeData.component,
+                `${prefix}${attribute}.${index}.`,
+                index
               )
-            : [
-                flattenEntity(
-                  value,
-                  allLayoutData,
-                  attributeData.component,
-                  prefix + attribute + '.'
-                ),
-              ])
-        )
+            )
+          )
+        } else {
+          _.assign(
+            result,
+            flattenEntity(
+              value,
+              allLayoutData,
+              attributeData.component,
+              prefix + attribute + '.'
+            )
+          )
+        }
       } else if (attributeData.type === 'dynamiczone' && Array.isArray(value)) {
         _.assign(
           result,


### PR DESCRIPTION
When some components are empty an error was thrown that data is null. This fixes that issue and additionally resets the content of a component if the translation is empty.

fix #472 