### PR TITLE
ci(e2e workflow): upgrade actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,8 +34,9 @@ jobs:
       - name: Run e2e tests
         run: yarn e2e
         working-directory: e2e
-      - uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload cypress results on failure
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
         with:
           name: cypress results (node=${{ matrix.node }},strapi=${{ matrix.strapi }})
           path: |


### PR DESCRIPTION
There should be no migration steps necessary, changing the version to v4 should be enough