### PR TITLE
feat(provider-deepl): omit placeholders plugin option

### DIFF
--- a/providers/deepl/README.md
+++ b/providers/deepl/README.md
@@ -21,6 +21,8 @@ module.exports = {
           // use uppercase here!
           EN: 'EN-US',
         },
+        // controls if placeholder text inside double curly brackets should be omitted from translation
+        omitPlaceholders: false,
         apiOptions: {
           // see <https://github.com/DeepLcom/deepl-node#text-translation-options> for supported options.
           // note that tagHandling Mode cannot be set this way.

--- a/providers/deepl/lib/__tests__/deepl.test.js
+++ b/providers/deepl/lib/__tests__/deepl.test.js
@@ -395,6 +395,27 @@ describe('deepl provider', () => {
         await expect(deeplProvider.usage()).resolves.toBeTruthy()
       })
 
+      it('omits placeholders when option used', async () => {
+        server.use(http.post(`${DEEPL_PAID_API}/translate`, translateHandler))
+
+        const deeplProvider = provider.init({
+          apiKey: authKey,
+          omitPlaceholders: true,
+        })
+
+        // given
+        const params = {
+          sourceLocale: 'en',
+          targetLocale: 'de',
+          text: 'Some text with a placeholder {{placeholder}} in it and an {{other}} one',
+        }
+        // when
+        const result = await deeplProvider.translate(params)
+
+        // then
+        expect(result).toEqual([params.text])
+      })
+
       describe('api options used', () => {
         const registerHandlerEnforceParams = (
           requiredParams,

--- a/providers/deepl/lib/index.js
+++ b/providers/deepl/lib/index.js
@@ -32,6 +32,7 @@ module.exports = {
         ? providerOptions.apiOptions
         : {}
     const omitPlaceholders = providerOptions.omitPlaceholders || false
+    const omitTags = providerOptions.omitTags || false
 
     const client = new deepl.Translator(apiKey, {
       serverUrl: apiUrl,
@@ -95,12 +96,22 @@ module.exports = {
         let textArray = Array.isArray(input) ? input : [input]
 
         let placeholderTexts = [];
+        let placeholderTags = [];
 
         if (omitPlaceholders) {
           textArray = textArray.map((text) =>
             text.replace(/{{(.*?)}}/g, (match) => {
               placeholderTexts.push(match)
               return `<m id=${placeholderTexts.length - 1} />`
+            })
+          )
+        }
+
+        if (omitTags) {
+          textArray = textArray.map((text) =>
+            text.replace(/<\/?[^>]+(>|$)/g, (match) => {
+              placeholderTags.push(match)
+              return `<t id=${placeholderTags.length - 1} />`
             })
           )
         }
@@ -142,6 +153,12 @@ module.exports = {
           result = result.map((text) =>
             text.replace(/<m id=(.*?) \/>/g, (_, id) => placeholderTexts[id])
           )
+        }
+
+        if (omitTags) {
+          result = result.map((text) =>
+            text.replace(/<t id=(.*?) \/>/g, (_, id) => placeholderTags[id])
+        )
         }
 
         if (format === 'jsonb') {

--- a/providers/deepl/lib/index.js
+++ b/providers/deepl/lib/index.js
@@ -102,20 +102,20 @@ module.exports = {
         let placeholderTexts = [];
         let placeholderTags = [];
 
-        if (omitPlaceholders) {
-          textArray = textArray.map((text) =>
-            text.replace(/{{(.*?)}}/g, (match) => {
-              placeholderTexts.push(match)
-              return `<m id=${placeholderTexts.length - 1} />`
-            })
-          )
-        }
-
         if (omitTags) {
           textArray = textArray.map((text) =>
             text.replace(/<\/?[^>]+(>|$)/g, (match) => {
               placeholderTags.push(match)
               return `<t id=${placeholderTags.length - 1} />`
+            })
+          )
+        }
+
+        if (omitPlaceholders) {
+          textArray = textArray.map((text) =>
+            text.replace(/{{(.*?)}}/g, (match) => {
+              placeholderTexts.push(match)
+              return `<m id=${placeholderTexts.length - 1} />`
             })
           )
         }
@@ -144,7 +144,7 @@ module.exports = {
           glossary = findGlossary(availableGlossaries, sourceLocale, targetLocale)?.glossaryId || glossary;
         }
 
-        const result = reduceFunction(
+        let result = reduceFunction(
           await Promise.all(
             chunks.map(async (texts) => {
               const result = await rateLimitedTranslate.withOptions(

--- a/providers/deepl/package.json
+++ b/providers/deepl/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "strapi-provider-translate-deepl",
-  "version": "1.2.7",
+  "name": "strapi-provider-translate-deepl-lokki",
+  "version": "1.2.9",
   "description": "DeepL provider for translate plugin in Strapi 4",
   "keywords": [
     "strapi",


### PR DESCRIPTION
## Changes
Adds an optional boolean `omitPlaceholders` provider option for the DeepL Provider that handles text inside double curly brackets, that can be used as placeholders or variable text.

Asked by #484 , but I also had the same need with collaborators on Strapi that want to mass translate text with those {{text}} inside.

## Explanation
Replicated the process explained in the example provider by Deepl:
https://developers.deepl.com/docs/resources/examples-and-guides/placeholder-tags
https://github.com/DeepLcom/deepl-python/blob/main/examples/mustache/README.md

### Steps:
When `omitPlaceholders` is `true`
- ⬅️  **Before the translation**: it creates and fills a temporary `placeholderTexts` array that contains the text that should be kept, while replacing the text with a simple `<m id=xx />` tag to keep the position of the placeholder in the text.

- ➡️  **After the translation**: it replaces back the tags with the original text thanks to the index saved inside the tag id.