### PR TITLE
fix(plugin): update default config to translate blocks

### DIFF
--- a/plugin/server/config/index.js
+++ b/plugin/server/config/index.js
@@ -8,6 +8,7 @@ module.exports = {
       translatedFieldTypes: [
         { type: 'string', format: 'plain' },
         { type: 'text', format: 'plain' },
+        { type: 'blocks', format: 'jsonb' },
         { type: 'richtext', format: 'markdown' },
         'component',
         'dynamiczone',


### PR DESCRIPTION
It is expected by the documentation that blocks are translated by default.

fixes #498