### PR TITLE
fix(provider-deepl): glossary handling

### DIFF
--- a/providers/deepl/lib/__tests__/deepl.test.js
+++ b/providers/deepl/lib/__tests__/deepl.test.js
@@ -524,12 +524,12 @@ describe('deepl provider', () => {
         if (!targetLang) {
           return new HttpResponse(null, { status: 400 })
         }
-        let glossary = params.get('glossary')
-        if (glossary) {
+        let glossary_id = params.get('glossary_id')
+        if (glossary_id) {
           return HttpResponse.json({
             translations: text.map((t) => ({
               detected_source_language: 'EN',
-              text: `${t} (glossary: ${glossary})`,
+              text: `${t} (glossary: ${glossary_id})`,
             })),
           })
         }

--- a/providers/deepl/lib/__tests__/deepl.test.js
+++ b/providers/deepl/lib/__tests__/deepl.test.js
@@ -524,12 +524,12 @@ describe('deepl provider', () => {
         if (!targetLang) {
           return new HttpResponse(null, { status: 400 })
         }
-        let glossary_id = params.get('glossary_id')
-        if (glossary_id) {
+        let glossary = params.get('glossary_id')
+        if (glossary) {
           return HttpResponse.json({
             translations: text.map((t) => ({
               detected_source_language: 'EN',
-              text: `${t} (glossary: ${glossary_id})`,
+              text: `${t} (glossary: ${glossary})`,
             })),
           })
         }

--- a/providers/deepl/lib/__tests__/deepl.test.js
+++ b/providers/deepl/lib/__tests__/deepl.test.js
@@ -507,4 +507,108 @@ describe('deepl provider', () => {
       })
     })
   })
+
+  describe('glossaries', () => {
+    const glossaryHandler = async ({ request }) => {
+      const body = await request.text()
+      const params = new URLSearchParams(body)
+      if (isAuthenticated(request)) {
+        let text = params.getAll('text')
+        if (text.length == 0) {
+          return new HttpResponse(null, { status: 400 })
+        }
+        if (text.length > 50) {
+          return new HttpResponse(null, { status: 413 })
+        }
+        let targetLang = params.get('target_lang')
+        if (!targetLang) {
+          return new HttpResponse(null, { status: 400 })
+        }
+        let glossary = params.get('glossary')
+        if (glossary) {
+          return HttpResponse.json({
+            translations: text.map((t) => ({
+              detected_source_language: 'EN',
+              text: `${t} (glossary: ${glossary})`,
+            })),
+          })
+        }
+        return HttpResponse.json({
+          translations: text.map((t) => ({
+            detected_source_language: 'EN',
+            text: t,
+          })),
+        })
+      }
+      return new HttpResponse(null, { status: 403 })
+    }
+
+    beforeEach(() => {
+      server.use(
+        http.post(`${DEEPL_FREE_API}/translate`, glossaryHandler),
+        http.post(`${DEEPL_PAID_API}/translate`, glossaryHandler)
+      )
+    })
+
+    it('uses the correct glossary for the given locale pair', async () => {
+      const deeplProvider = provider.init({
+        apiKey: authKey,
+        glossaries: [
+          {
+            id: 'glossary1',
+            source_lang: 'EN',
+            target_lang: 'DE',
+          },
+          {
+            id: 'glossary2',
+            source_lang: 'EN',
+            target_lang: 'FR',
+          },
+        ],
+      })
+
+      const params = {
+        sourceLocale: 'en',
+        targetLocale: 'de',
+        text: 'Some text',
+      }
+
+      const result = await deeplProvider.translate(params)
+
+      expect(result).toEqual(['Some text (glossary: glossary1)'])
+    })
+
+    it('ignores glossary in apiOptions and logs a warning', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
+
+      const deeplProvider = provider.init({
+        apiKey: authKey,
+        glossaries: [
+          {
+            id: 'glossary1',
+            source_lang: 'EN',
+            target_lang: 'DE',
+          },
+        ],
+        apiOptions: {
+          glossary: 'someOtherGlossary',
+        },
+      })
+
+      const params = {
+        sourceLocale: 'en',
+        targetLocale: 'de',
+        text: 'Some text',
+      }
+
+      const result = await deeplProvider.translate(params)
+
+      expect(result).toEqual(['Some text (glossary: glossary1)'])
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Glossary provided in apiOptions will be ignored and overwritten by the actual glossary that should be used for this translation.'
+      )
+
+      consoleWarnSpy.mockRestore()
+    })
+  })
 })


### PR DESCRIPTION
Fixes #500

Add support for multiple glossaries in the deepl provider.

- Update `providers/deepl/lib/index.js` to handle multiple glossaries from `providerOptions` and select the appropriate glossary based on the source and target locale.
- Add logic to convert source and target language using `parseLocale` function.
- Add a warning log if a glossary is provided in `apiOptions` and overwrite it with the actual glossary to be used for the translation.
- Write tests in `providers/deepl/lib/__tests__/deepl.test.js` to verify that glossaries are handled correctly and that a warning is logged when a glossary is provided in `apiOptions`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Fekide/strapi-plugin-translate/pull/501?shareId=2d97d358-9c46-4a6f-92f8-5dee981efc05).