### PR TITLE
fix(provider-deepl): glossary handling

### DIFF
--- a/providers/deepl/README.md
+++ b/providers/deepl/README.md
@@ -21,9 +21,17 @@ module.exports = {
           // use uppercase here!
           EN: 'EN-US',
         },
+        // Optional: Pass glossaries on translation. The correct glossary for each translation is selected by the target_lang and source_lang properties 
+        glossaries: [
+          {
+            id: "your-glossary-id",
+            target_lang: "DE",
+            source_lang: "EN",
+          }
+        ],
         apiOptions: {
           // see <https://github.com/DeepLcom/deepl-node#text-translation-options> for supported options.
-          // note that tagHandling Mode cannot be set this way.
+          // note that tagHandling Mode and glossary cannot be set this way.
           // use with caution, as non-default values may break translation of markdown
           formality: 'default',
           // ...


### PR DESCRIPTION
add support for handling multiple glossaries

fixes #500

- Update `providers/deepl/lib/index.js` to handle multiple glossaries from `providerOptions` and select the appropriate glossary based on the source and target locale.
- Add logic to convert source and target language using `parseLocale` function.
- Add a warning log if a glossary is provided in `apiOptions` and overwrite it with the actual glossary to be used for the translation.
- Write tests in `providers/deepl/lib/__tests__/deepl.test.js` to verify that glossaries are handled correctly and that a warning is logged when a glossary is provided in `apiOptions`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Fekide/strapi-plugin-translate/pull/501?shareId=2d97d358-9c46-4a6f-92f8-5dee981efc05).