### PR TITLE
fix(plugin): empty or whitespace-only fields

### DIFF
--- a/plugin/server/services/translate.js
+++ b/plugin/server/services/translate.js
@@ -44,6 +44,11 @@ module.exports = ({ strapi }) => ({
         const textsToTranslate = groupedFields[format].map(({ field }) =>
           get(data, field, '')
         )
+
+        if (textsToTranslate.length === 0) {
+          return
+        }
+
         const translateResult = await strapi
           .plugin('translate')
           .provider.translate({

--- a/plugin/server/utils/__tests__/translatable-fields.test.js
+++ b/plugin/server/utils/__tests__/translatable-fields.test.js
@@ -130,6 +130,50 @@ describe('translatable fields', () => {
       expect(translatedField).toBeNull()
     })
 
+    it('text field with empty string not translated', async () => {
+      // given
+      const data = { field: '' }
+      const schema = {
+        type: 'text',
+        pluginOptions: { translate: { translate: 'translate' } },
+      }
+      const attr = 'field'
+      const translatedFieldTypes = ['text']
+
+      // when
+      const translatedField = await getTranslateFields(
+        data,
+        schema,
+        attr,
+        translatedFieldTypes
+      )
+
+      // then
+      expect(translatedField).toBeNull()
+    })
+
+    it('text field with whitespace string not translated', async () => {
+      // given
+      const data = { field: '   ' }
+      const schema = {
+        type: 'text',
+        pluginOptions: { translate: { translate: 'translate' } },
+      }
+      const attr = 'field'
+      const translatedFieldTypes = ['text']
+
+      // when
+      const translatedField = await getTranslateFields(
+        data,
+        schema,
+        attr,
+        translatedFieldTypes
+      )
+
+      // then
+      expect(translatedField).toBeNull()
+    })
+
     it('other field not translated', async () => {
       // given
       const data = { field: 'some text' }

--- a/plugin/server/utils/translatable-fields.js
+++ b/plugin/server/utils/translatable-fields.js
@@ -70,6 +70,10 @@ async function getTranslateFields(data, schema, attr) {
         )
       )
     } else {
+      const fieldData = _.get(data, attr, undefined)
+      if (typeof fieldData === 'string' && fieldData.trim() === '') {
+        return null
+      }
       return {
         field: attr,
         format: getFieldTypeFormat(schema.type),


### PR DESCRIPTION
* **plugin/server/services/translate.js**
  - Skip translation if array is empty
* **plugin/server/utils/__tests__/translatable-fields.test.js**
  - Add tests to verify that empty or whitespace-only fields are not translated.
* **plugin/server/utils/translatable-fields.js**
  - Add check to ignore fields with empty or whitespace-only strings before translation.

fixes #252