### PR TITLE
Expose inner exception when batch fails

### DIFF
--- a/plugin/server/src/services/batch-translate/BatchTranslateJobExecutor.ts
+++ b/plugin/server/src/services/batch-translate/BatchTranslateJobExecutor.ts
@@ -278,7 +278,8 @@ export class BatchTranslateJobExecutor {
         })
         clearInterval(this.intervalId)
         throw new Error(
-          `Translation of entity ${entity.documentId} from ${this.sourceLocale} to ${this.targetLocale} failed`
+          `Translation of entity ${entity.documentId} from ${this.sourceLocale} to ${this.targetLocale} failed: ${error.message}`,
+          { cause: error }
         )
       }
       await this.updateProgress()


### PR DESCRIPTION
Exposes `error.message` in the error thrown by BatchTranslateJobExecutor.

Also sets the cause property. Due to a lagging `winston` dependency in strapi, the cause is not yet printed to the console. Hopefully strapi will update this dependency some day which presents the cause to the strapi console log.

Whenever that happens, the message could again be removed from the error message.