### PR TITLE
fix(parse-locale.js in deepl): translation is not working for traditional chinese locales(zh-Hant)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,4 +136,3 @@ build/
 
 **/cypress/videos
 **/cypress/screenshots
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ build/
 
 **/cypress/videos
 **/cypress/screenshots
+.idea

--- a/providers/deepl/lib/__tests__/parse-locale.test.js
+++ b/providers/deepl/lib/__tests__/parse-locale.test.js
@@ -74,4 +74,18 @@ describe('locale parser', () => {
   it('source language is parsed without specific locale even with locale map', () => {
     expect(parseLocale('en-GB', {}, 'source')).toEqual('EN')
   })
+    it('source language is parsed without specific locale for zh-Hant-tw', () => {
+        const localeMap = {
+            'ZH-HANT-TW': 'ZH-HANT',
+            'ZH-HANT': 'ZH-HANT',
+        };
+        expect(parseLocale('zh-Hant-tw', localeMap)).toEqual('ZH-HANT');
+    })
+    it('source language is parsed without specific locale for zh-Hant', () => {
+        const localeMap = {
+            'ZH-HANT-TW': 'ZH-HANT',
+            'ZH-HANT': 'ZH-HANT',
+        };
+        expect(parseLocale('zh-Hant', localeMap)).toEqual('ZH-HANT');
+    })
 })

--- a/providers/deepl/lib/parse-locale.js
+++ b/providers/deepl/lib/parse-locale.js
@@ -55,7 +55,7 @@ function parseLocale(strapiLocale, localeMap = {}, direction = 'target') {
     case 'TR':
     case 'UK':
     case 'ZH':
-      possiblyUnstrippedResult = localeMap[stripped] || stripped
+      possiblyUnstrippedResult = localeMap[unstripped] || localeMap[stripped] || stripped
       break
     case 'PT':
       if (unstripped == 'PT-PT') possiblyUnstrippedResult = unstripped


### PR DESCRIPTION
always translating to the simplified Chinese locale even though I am trying to do it for a traditional locale.