### PR TITLE
fix: type.attributes.map is not a function & batch translation  

### DIFF
--- a/plugin/admin/src/utils/mutateCTBContentTypeSchema.ts
+++ b/plugin/admin/src/utils/mutateCTBContentTypeSchema.ts
@@ -6,43 +6,34 @@ const localizedPath = ['pluginOptions', 'i18n', 'localized']
 const translatePath = ['pluginOptions', 'translate', 'translate']
 
 const addTranslationToFields = (attributes: Schema.ContentType['attributes']) =>
-  Object.keys(attributes).reduce<Schema.ContentType['attributes']>(
-    (acc, current) => {
-      const currentAttribute = attributes[current]
+  Object.values(attributes).map((currentAttribute) => {
+    const attributeIsLocalized = get(currentAttribute, localizedPath, true)
 
-      const attributeIsLocalized = get(currentAttribute, localizedPath, true)
+    const attributeDefaultTranslated =
+      currentAttribute.type === 'relation' || attributeIsLocalized
 
-      const attributeDefaultTranslated =
-        currentAttribute.type === 'relation' || attributeIsLocalized
-
-      if (
-        attributeDefaultTranslated &&
-        TRANSLATABLE_FIELDS.includes(currentAttribute.type)
-      ) {
-        const translate = {
-          translate: get(
-            currentAttribute,
-            translatePath,
-            attributeDefaultTranslated ? 'translate' : 'copy'
-          ),
-        }
-
-        const pluginOptions = {
-          ...(currentAttribute.pluginOptions ?? {}),
-          translate,
-        }
-
-        acc[current] = { ...currentAttribute, pluginOptions }
-
-        return acc
+    if (
+      attributeDefaultTranslated &&
+      TRANSLATABLE_FIELDS.includes(currentAttribute.type)
+    ) {
+      const translate = {
+        translate: get(
+          currentAttribute,
+          translatePath,
+          attributeDefaultTranslated ? 'translate' : 'copy'
+        ),
       }
 
-      acc[current] = currentAttribute
+      const pluginOptions = {
+        ...(currentAttribute.pluginOptions ?? {}),
+        translate,
+      }
 
-      return acc
-    },
-    {}
-  )
+      return { ...currentAttribute, pluginOptions }
+    }
+
+    return currentAttribute
+  })
 
 type OmitByPath<T extends object, K extends string[]> = Pick<
   T,

--- a/plugin/server/src/utils/clean-data.ts
+++ b/plugin/server/src/utils/clean-data.ts
@@ -83,6 +83,14 @@ export function cleanData<
       }
     }
   })
+
+  // Remove empty arrays after all processing
+  Object.keys(resultData).forEach((key) => {
+    if (Array.isArray(resultData[key]) && resultData[key].length === 0) {
+      delete resultData[key]
+    }
+  })
+
   return resultData as unknown as Utils.If<
     ForFrontend,
     Modules.Documents.Document<TSchemaUID>,

--- a/plugin/server/src/utils/clean-data.ts
+++ b/plugin/server/src/utils/clean-data.ts
@@ -82,12 +82,10 @@ export function cleanData<
         resultData[attr] = mediaFiles.id
       }
     }
-  })
 
-  // Remove empty arrays after all processing
-  Object.keys(resultData).forEach((key) => {
-    if (Array.isArray(resultData[key]) && resultData[key].length === 0) {
-      delete resultData[key]
+    // Remove attribute if it's an empty array
+    if (Array.isArray(resultData[attr]) && resultData[attr].length === 0) {
+      delete resultData[attr]
     }
   })
 


### PR DESCRIPTION
* **fix: type.attributes.map is not a function** (#526) 
This [comment](https://github.com/Fekide/strapi-plugin-translate/issues/404#issuecomment-3362494435) mentioned the root of the error. The reducer in `addTranslationToFields` uses `{}` as inital value. Due to typing issues I could not replace the object with an empty array. Using `Objec.values` and `map` instead returns the expected array. 

* **fix: batch translation update fails due to empty relations** (#532)
For batch translation we always got an error that the translation failed, but we where seeing that tokens had been used on deepl. 
`translateEntity` from the translate service threw the error and I could trace it back to `strapi.documents(params.contentType).update` in this method, which was throwing due to some entries in the `cleanedData` object where `relationName: []`. I added a fix to delete all empty arrays from the object before returning it. With this fix, all updates where working correct again. 

ℹ️ 
As our content team was running into these issues with the beta I attempted a fix which is working fine for us. Maybe the fixes can be released as a update for the current `next` version so others can make use of it, if the fixes are fine and approved. At least somebody may use my fixes as a reference if the need to patch it them selfs. 
Let me know if you need any more infos here or feel free to close this PR if is not of use. 
Thanks for this awesome plugin. 
