### PR TITLE
PR to match #535 enable support for DeepL beta languages

### DIFF
--- a/providers/deepl/README.md
+++ b/providers/deepl/README.md
@@ -51,6 +51,21 @@ or use the default environment variables:
 
 To get an API key, register for free at [www.deepl.com/pro#developer](https://www.deepl.com/pro#developer).
 
+ ### Beta Languages
+
+  To enable DeepL beta languages (e.g., Croatian, Hindi), add:
+
+  \`\`\`javascript
+  providerOptions: {
+    enableBetaLanguages: true,
+    localeMap: {
+      HR: 'HR',  // Croatian (beta)
+    }
+  }
+  \`\`\`
+
+  Note: Beta languages must also be added to `localeMap` to bypass the locale validation.
+
 ## Limitations:
 
 - Only the [deepl supported languages](https://www.deepl.com/docs-api/translating-text/request/) can be translated

--- a/providers/deepl/lib/index.js
+++ b/providers/deepl/lib/index.js
@@ -31,6 +31,7 @@ module.exports = {
       typeof providerOptions.apiOptions === 'object'
         ? providerOptions.apiOptions
         : {}
+    const enableBetaLanguages = providerOptions.enableBetaLanguages || apiOptions.enableBetaLanguages || false
     const glossaries =
       Array.isArray(providerOptions.glossaries)
         ? providerOptions.glossaries
@@ -110,7 +111,14 @@ module.exports = {
                 texts,
                 parsedSourceLocale,
                 parsedTargetLocale,
-                { ...apiOptions, tagHandling, glossary }
+                {   ...apiOptions, 
+                   tagHandling, 
+                   glossary,
+                   extraRequestParameters: {
+                    ...(apiOptions.extraRequestParameters || {}),
+                    ...(enableBetaLanguages ? { enable_beta_languages: '1' } : {})
+                  }
+                }
               )
               return result.map((value) => value.text)
             })


### PR DESCRIPTION
Small patch to enable providing `enable_beta_languages` to the DeepL API via configuration and added the needed documentation to the read me.

Tested locally with enabling support for Croatian and running it against one of my content types.