### PR TITLE
docs: add Langbly to available providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ module.exports = {
 #### Available providers
 
 - [strapi-provider-translate-deepl](https://www.npmjs.com/package/strapi-provider-translate-deepl)
+- [strapi-provider-translate-langbly](https://www.npmjs.com/package/strapi-provider-translate-langbly)
 - [strapi-provider-translate-libretranslate](https://www.npmjs.com/package/strapi-provider-translate-libretranslate)
 
 ### Configure translation of individual fields/attributes

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -98,6 +98,7 @@ module.exports = {
 #### Available providers
 
 - [strapi-provider-translate-deepl](https://www.npmjs.com/package/strapi-provider-translate-deepl)
+- [strapi-provider-translate-langbly](https://www.npmjs.com/package/strapi-provider-translate-langbly)
 - [strapi-provider-translate-libretranslate](https://www.npmjs.com/package/strapi-provider-translate-libretranslate)
 
 ### Configure translation of individual fields/attributes


### PR DESCRIPTION
Adds [strapi-provider-translate-langbly](https://www.npmjs.com/package/strapi-provider-translate-langbly) to the available providers list in both README files.

Langbly is a Google Translate v2 compatible translation API. The provider supports all field types (plain text, rich text, markdown, blocks/jsonb) with built-in rate limiting and automatic chunking.

- npm: https://www.npmjs.com/package/strapi-provider-translate-langbly
- GitHub: https://github.com/Langbly/strapi-provider-translate-langbly
- Docs: https://langbly.com/docs